### PR TITLE
AAC-495 MAAT / LAA Reference - POST Endpoint

### DIFF
--- a/laa_court_data_api_app/main.py
+++ b/laa_court_data_api_app/main.py
@@ -4,7 +4,7 @@ import uvicorn
 from fastapi import FastAPI
 
 from laa_court_data_api_app.config.app import get_app_settings
-from .routers import defendants, hearing, hearing_summaries, hearing_events, ping, laa_references
+from .routers import defendants, hearing, hearing_summaries, hearing_events, laa_references, ping
 
 
 logging.config.fileConfig('logging.conf', disable_existing_loggers=False)
@@ -25,8 +25,8 @@ app.include_router(defendants.router)
 app.include_router(hearing.router)
 app.include_router(hearing_summaries.router)
 app.include_router(hearing_events.router)
-app.include_router(ping.router)
 app.include_router(laa_references.router)
+app.include_router(ping.router)
 
 if __name__ == '__main__':
     uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/laa_court_data_api_app/models/laa_references/external/request/laa_references_patch.py
+++ b/laa_court_data_api_app/models/laa_references/external/request/laa_references_patch.py
@@ -8,3 +8,13 @@ class LaaReferencesPatch(BaseModel):
     defendant_id: UUID | None
     maat_reference: int | None
     unlink_reason_code: int | None
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "user_name": "jon-5",
+                "defendant_id": "d7f509e8-309c-4262-a41d-ebbb44deab9e",
+                "maat_reference": 1234567,
+                "unlink_reason_code": 0
+            }
+        }

--- a/laa_court_data_api_app/models/laa_references/external/request/laa_references_patch_request.py
+++ b/laa_court_data_api_app/models/laa_references/external/request/laa_references_patch_request.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 from laa_court_data_api_app.models.laa_references.external.request.laa_references_patch import LaaReferencesPatch

--- a/laa_court_data_api_app/models/laa_references/external/request/laa_references_post.py
+++ b/laa_court_data_api_app/models/laa_references/external/request/laa_references_post.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class LaaReferencesPost(BaseModel):
+    user_name: str | None
+    defendant_id: UUID | None
+    maat_reference: int | None
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "user_name": "jon-5",
+                "defendant_id": "d7f509e8-309c-4262-a41d-ebbb44deab9e",
+                "maat_reference": 1234567,
+            }
+        }

--- a/laa_court_data_api_app/models/laa_references/external/request/laa_references_post_request.py
+++ b/laa_court_data_api_app/models/laa_references/external/request/laa_references_post_request.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_post import LaaReferencesPost
+
+
+class LaaReferencesPostRequest(BaseModel):
+    laa_reference: LaaReferencesPost | None

--- a/laa_court_data_api_app/models/laa_references/internal/request/laa_references_post.py
+++ b/laa_court_data_api_app/models/laa_references/internal/request/laa_references_post.py
@@ -1,0 +1,9 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class LaaReferencesPost(BaseModel):
+    user_name: str | None
+    defendant_id: UUID | None
+    maat_reference: int | None

--- a/laa_court_data_api_app/models/laa_references/internal/request/laa_references_post_request.py
+++ b/laa_court_data_api_app/models/laa_references/internal/request/laa_references_post_request.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+from laa_court_data_api_app.models.laa_references.internal.request.laa_references_post import LaaReferencesPost
+
+
+class LaaReferencesPostRequest(BaseModel):
+    laa_reference: LaaReferencesPost | None

--- a/laa_court_data_api_app/routers/laa_references.py
+++ b/laa_court_data_api_app/routers/laa_references.py
@@ -6,10 +6,14 @@ from fastapi.responses import Response, JSONResponse
 from laa_court_data_api_app.internal.court_data_adaptor_client import CourtDataAdaptorClient
 from laa_court_data_api_app.models.laa_references.external.request.laa_references_patch_request import \
     LaaReferencesPatchRequest as ExternalPatchRequest
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_post_request import \
+    LaaReferencesPostRequest as ExternalPostRequest
 from laa_court_data_api_app.models.laa_references.external.response.laa_references_error_response import \
     LaaReferencesErrorResponse
 from laa_court_data_api_app.models.laa_references.internal.request.laa_references_patch_request import \
     LaaReferencesPatchRequest as InternalPatchRequest
+from laa_court_data_api_app.models.laa_references.internal.request.laa_references_post_request import \
+    LaaReferencesPostRequest as InternalPostRequest
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -23,20 +27,35 @@ responses = {
 }
 
 
-@router.patch("/v2/laa_references/{defendant_id}", responses=responses)
+@router.patch("/v2/laa_references/{defendant_id}", status_code=202, responses=responses)
 async def patch_maat_unlink(defendant_id: str, request: ExternalPatchRequest):
     logger.info(f"Calling_Maat_Patch_{defendant_id}")
     client = CourtDataAdaptorClient()
     cda_response = await client.patch(f'/api/internal/v2/laa_references/{defendant_id}',
                                       body=InternalPatchRequest(**request.dict()))
 
+    return formulated_response(cda_response, defendant_id, "Unlinking")
+
+
+@router.post("/v2/laa_references/", status_code=202, responses=responses)
+async def post_maat_link(request: ExternalPostRequest):
+    laa_reference_details = request.laa_reference
+    logger.info("Calling_Maat_Post_{laa_reference_details.defendant_id}")
+    client = CourtDataAdaptorClient()
+
+    cda_response = await client.post(f"/api/internal/v2/laa_references/", body=InternalPostRequest(**request.dict()))
+
+    return formulated_response(cda_response, laa_reference_details.defendant_id, "Linking")
+
+
+def formulated_response(cda_response, defendant_id, request_type):
     if cda_response is None:
         logging.error("Laa_References_Endpoint_Did_Not_Return")
         return Response(status_code=424)
 
     match cda_response.status_code:
         case 202:
-            logging.info(f"Maat_Id_For_{defendant_id}_Successfully_Requested")
+            logging.info(f"Maat_Id_For_{defendant_id}_{request_type}_Successfully_Requested")
             return Response(status_code=202)
         case 400:
             logging.info(f"Validation_Failed_For_{defendant_id}")
@@ -45,7 +64,7 @@ async def patch_maat_unlink(defendant_id: str, request: ExternalPatchRequest):
             logging.info(f"Laa_References_Endpoint_Not_Found")
             return Response(status_code=404)
         case 422:
-            logging.info(f"Unable_To_Process_Unlink_For_{defendant_id}")
+            logging.info(f"Unable_To_Process_{request_type}_For_{defendant_id}")
             return JSONResponse(status_code=422, content=LaaReferencesErrorResponse(**cda_response.json()).dict())
         case _:
             logging.error(f"Laa_References_Endpoint_Error_Returning")

--- a/postman/collections/laa_references.postman_collection.json
+++ b/postman/collections/laa_references.postman_collection.json
@@ -7,6 +7,19 @@
 	"item": [
 		{
 			"name": "LAA Reference Link",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 422\", function () {",
+							"    pm.response.to.have.status(422);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [
@@ -45,7 +58,7 @@
 			"response": []
 		},
 		{
-			"name": "New Request",
+			"name": "LAA Reference UnLink",
 			"event": [
 				{
 					"listen": "test",

--- a/postman/collections/laa_references.postman_collection.json
+++ b/postman/collections/laa_references.postman_collection.json
@@ -1,10 +1,62 @@
 {
 	"info": {
-		"_postman_id": "607dec41-e7fa-442e-9d75-ca5926e786cf",
+		"_postman_id": "01be156c-302e-4db9-8b53-fa0bbbbe374b",
 		"name": "Laa References",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
+		{
+			"name": "LAA Reference Link",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 202\", function () {",
+							"    pm.response.to.have.status(202);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Basic {{Username}}",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"laa_reference\": {\n        \"user_name\": \"jon-5\",\n        \"defendant_id\": \"{{DefendantId}}\",\n        \"maat_reference\": {{MaatReference}}\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{BaseUrl}}/v2/laa_references/",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"v2",
+						"laa_references",
+						""
+					]
+				}
+			},
+			"response": []
+		},
 		{
 			"name": "New Request",
 			"event": [

--- a/postman/collections/laa_references.postman_collection.json
+++ b/postman/collections/laa_references.postman_collection.json
@@ -7,19 +7,6 @@
 	"item": [
 		{
 			"name": "LAA Reference Link",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 202\", function () {",
-							"    pm.response.to.have.status(202);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
 			"request": {
 				"method": "POST",
 				"header": [

--- a/test/routers/fixtures.py
+++ b/test/routers/fixtures.py
@@ -9,8 +9,12 @@ from laa_court_data_api_app.models.hearing.hearing import Hearing
 from laa_court_data_api_app.models.hearing.hearing_result import HearingResult
 from laa_court_data_api_app.models.hearing_events.hearing_events_result import HearingEventsResult
 from laa_court_data_api_app.models.hearing_summaries.hearing_summary import HearingSummary
-from laa_court_data_api_app.models.laa_references.external.response.laa_references_error_response import \
-    LaaReferencesErrorResponse
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_patch import LaaReferencesPatch
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_patch_request import \
+    LaaReferencesPatchRequest
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_post import LaaReferencesPost
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_post_request import \
+    LaaReferencesPostRequest
 from laa_court_data_api_app.models.prosecution_cases.defendant_summary import DefendantSummary
 from laa_court_data_api_app.models.prosecution_cases.prosecution_cases import ProsecutionCases
 from laa_court_data_api_app.models.prosecution_cases.prosecution_cases_results import ProsecutionCasesResults
@@ -48,13 +52,8 @@ def get_hearing_results():
 
 
 @pytest.fixture()
-def get_laa_references_error():
-    return LaaReferencesErrorResponse(error="test")
-
-
-@pytest.fixture()
 def mock_cda_client(get_new_token_response, get_prosecution_case_results,
-                    get_hearing_results, get_hearing_events_results, get_laa_references_error):
+                    get_hearing_results, get_hearing_events_results):
     with respx.mock(assert_all_called=False) as respx_mock:
         get_route = respx_mock.post("http://test-url/oauth/token", name="token_endpoint")
         get_route.return_value = Response(200, json=get_new_token_response.dict())
@@ -159,26 +158,17 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
             name="exception_hearing_events_uuid_route")
         exception_urn_uuid_route.return_value = Response(500)
 
-        laa_references_patch_accepted_route = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/12345", name="laa_references_patch_accepted_route")
-        laa_references_patch_accepted_route.return_value = Response(202)
+        # patch /laa_references
+        respx_mock.patch(
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
+            name="laa_references_patch_route",
+            json=LaaReferencesPatchRequest(laa_reference=LaaReferencesPatch()).dict())
 
-        laa_references_patch_bad_request_route = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/12346", name="laa_references_patch_bad_request_route")
-        laa_references_patch_bad_request_route.return_value = Response(400, json=get_laa_references_error.dict())
+        # post /laa_references
 
-        laa_references_patch_not_found_route = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/12347", name="laa_references_patch_not_found_route")
-        laa_references_patch_not_found_route.return_value = Response(404)
-
-        laa_references_patch_unprocessable_entity_route = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/12348",
-            name="laa_references_patch_unprocessable_entity_route")
-        laa_references_patch_unprocessable_entity_route.return_value = Response(422,
-                                                                                json=get_laa_references_error.dict())
-
-        laa_references_patch_server_error_route = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/12349", name="laa_references_patch_server_error_route")
-        laa_references_patch_server_error_route.return_value = Response(424)
+        respx_mock.post(
+            "http://test-url/api/internal/v2/laa_references/", name="laa_references_post_route",
+            json=LaaReferencesPostRequest(laa_reference=LaaReferencesPost()).dict()
+        )
 
         yield respx_mock

--- a/test/routers/laa_references/patch_test.py
+++ b/test/routers/laa_references/patch_test.py
@@ -7,7 +7,9 @@ from laa_court_data_api_app.main import app
 from laa_court_data_api_app.models.laa_references.external.request.laa_references_patch import LaaReferencesPatch
 from laa_court_data_api_app.models.laa_references.external.request.laa_references_patch_request import \
     LaaReferencesPatchRequest
-from ..routers.fixtures import *
+from laa_court_data_api_app.models.laa_references.external.response.laa_references_error_response import \
+    LaaReferencesErrorResponse
+from ..fixtures import *
 
 client = TestClient(app)
 
@@ -21,12 +23,14 @@ def test_laa_references_patch_returns_accepted(mock_settings, mock_cda_settings,
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/12345",
+    mock_cda_client["laa_references_patch_route"].return_value = Response(202)
+
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
                             json=LaaReferencesPatchRequest(laa_reference=LaaReferencesPatch()).dict())
 
     assert response.status_code == 202
     assert response.content == b''
-    assert mock_cda_client["laa_references_patch_accepted_route"].called
+    assert mock_cda_client["laa_references_patch_route"].called
 
 
 @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
@@ -38,13 +42,15 @@ def test_laa_references_patch_returns_bad_request(mock_settings, mock_cda_settin
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/12346",
+    mock_cda_client["laa_references_patch_route"].return_value = Response(
+        400, json=LaaReferencesErrorResponse(error="test").dict())
+
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
                             json=LaaReferencesPatchRequest(laa_reference=LaaReferencesPatch()).dict())
 
     assert response.status_code == 400
-    assert mock_cda_client["laa_references_patch_bad_request_route"].called
-    body = LaaReferencesErrorResponse(**response.json())
-    assert body.error == "test"
+    assert mock_cda_client["laa_references_patch_route"].called
+    assert response.content == b'{"error":"test"}'
 
 
 @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
@@ -56,12 +62,14 @@ def test_laa_references_patch_returns_not_found(mock_settings, mock_cda_settings
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/12347",
+    mock_cda_client["laa_references_patch_route"].return_value = Response(404)
+
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
                             json=LaaReferencesPatchRequest(laa_reference=LaaReferencesPatch()).dict())
 
     assert response.status_code == 404
     assert response.content == b''
-    assert mock_cda_client["laa_references_patch_not_found_route"].called
+    assert mock_cda_client["laa_references_patch_route"].called
 
 
 @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
@@ -73,13 +81,15 @@ def test_laa_references_patch_returns_unprocessable_entity(mock_settings, mock_c
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/12348",
+    mock_cda_client["laa_references_patch_route"].return_value = Response(
+        422, json=LaaReferencesErrorResponse(error="test").dict())
+
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
                             json=LaaReferencesPatchRequest(laa_reference=LaaReferencesPatch()).dict())
 
     assert response.status_code == 422
-    assert mock_cda_client["laa_references_patch_unprocessable_entity_route"].called
-    body = LaaReferencesErrorResponse(**response.json())
-    assert body.error == "test"
+    assert mock_cda_client["laa_references_patch_route"].called
+    assert response.content == b'{"error":"test"}'
 
 
 @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
@@ -91,25 +101,27 @@ def test_laa_references_patch_returns_server_error(mock_settings, mock_cda_setti
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/12349",
+    mock_cda_client["laa_references_patch_route"].return_value = Response(424)
+
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
                             json=LaaReferencesPatchRequest(laa_reference=LaaReferencesPatch()).dict())
 
     assert response.status_code == 424
     assert response.content == b''
-    assert mock_cda_client["laa_references_patch_server_error_route"].called
+    assert mock_cda_client["laa_references_patch_route"].called
 
 
 @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
 @patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
        new_callable=PropertyMock)
-def test_hearing_summaries_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
-                                        mock_cda_client):
+def test_laa_references_patch_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                           mock_cda_client):
     OauthClient().token = None
     mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     mock_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/12349",
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
                             json=LaaReferencesPatchRequest(laa_reference=LaaReferencesPatch()).dict())
 
     assert response.status_code == 424

--- a/test/routers/laa_references/post_test.py
+++ b/test/routers/laa_references/post_test.py
@@ -1,0 +1,129 @@
+from unittest.mock import patch, PropertyMock
+
+from fastapi.testclient import TestClient
+
+from laa_court_data_api_app.internal.oauth_client import OauthClient
+from laa_court_data_api_app.main import app
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_post import LaaReferencesPost
+from laa_court_data_api_app.models.laa_references.external.request.laa_references_post_request import \
+    LaaReferencesPostRequest
+from laa_court_data_api_app.models.laa_references.external.response.laa_references_error_response import \
+    LaaReferencesErrorResponse
+from ..fixtures import *
+
+client = TestClient(app)
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_laa_references_post_returns_accepted(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                              mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+
+    mock_cda_client["laa_references_post_route"].return_value = Response(202)
+
+    response = client.post("/v2/laa_references/",
+                           json=LaaReferencesPostRequest(laa_reference=LaaReferencesPost()).dict())
+
+    assert response.status_code == 202
+    assert response.content == b''
+    assert mock_cda_client["laa_references_post_route"].called
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_laa_references_post_returns_bad_request(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                                 mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+
+    mock_cda_client["laa_references_post_route"].return_value = Response(
+        400, json=LaaReferencesErrorResponse(error="test").dict())
+
+    response = client.post("/v2/laa_references/",
+                           json=LaaReferencesPostRequest(laa_reference=LaaReferencesPost()).dict())
+
+    assert response.status_code == 400
+    assert mock_cda_client["laa_references_post_route"].called
+    assert response.content == b'{"error":"test"}'
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_laa_references_post_returns_not_found(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                               mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+
+    mock_cda_client["laa_references_post_route"].return_value = Response(404)
+
+    response = client.post("/v2/laa_references/",
+                           json=LaaReferencesPostRequest(laa_reference=LaaReferencesPost()).dict())
+
+    assert response.status_code == 404
+    assert response.content == b''
+    assert mock_cda_client["laa_references_post_route"].called
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_laa_references_post_returns_unprocessable_entity(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                                          mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+
+    mock_cda_client["laa_references_post_route"].return_value = Response(
+        422, json=LaaReferencesErrorResponse(error="test").dict())
+
+    response = client.post("/v2/laa_references/",
+                           json=LaaReferencesPostRequest(laa_reference=LaaReferencesPost()).dict())
+
+    assert response.status_code == 422
+    assert mock_cda_client["laa_references_post_route"].called
+    assert response.content == b'{"error":"test"}'
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_laa_references_post_returns_server_error(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                                  mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+
+    mock_cda_client["laa_references_post_route"].return_value = Response(424)
+
+    response = client.post("/v2/laa_references/",
+                           json=LaaReferencesPostRequest(laa_reference=LaaReferencesPost()).dict())
+
+    assert response.status_code == 424
+    assert response.content == b''
+    assert mock_cda_client["laa_references_post_route"].called
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_laa_references_post_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                          mock_cda_client):
+    OauthClient().token = None
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+                                                 cda_uid="12345")
+    mock_settings.return_value = override_get_cda_settings
+
+    response = client.post("/v2/laa_references/",
+                           json=LaaReferencesPostRequest(laa_reference=LaaReferencesPost()).dict())
+
+    assert response.status_code == 424
+    assert response.content == b''
+    assert mock_cda_client["failed_token_endpoint"].called

--- a/test/routers/laa_references/post_test.py
+++ b/test/routers/laa_references/post_test.py
@@ -4,9 +4,6 @@ from fastapi.testclient import TestClient
 
 from laa_court_data_api_app.internal.oauth_client import OauthClient
 from laa_court_data_api_app.main import app
-from laa_court_data_api_app.models.laa_references.external.request.laa_references_post import LaaReferencesPost
-from laa_court_data_api_app.models.laa_references.external.request.laa_references_post_request import \
-    LaaReferencesPostRequest
 from laa_court_data_api_app.models.laa_references.external.response.laa_references_error_response import \
     LaaReferencesErrorResponse
 from ..fixtures import *


### PR DESCRIPTION
## Add a MAAT / LAA Reference - POST Endpoint

- Add laa_references POST models
- Update laa_references PATCH models
- Add route for laa_references POST endpoint
- Add postman tests for laa_references POST calls
- Add tests for laa_references POST calls
- Create a folder laa_references in the tests/routers directory for readability.
- Update the fixtures by adding a POST laa_references route and updating the PATCH route

> Pull out the mocked responses of the POST request to CDA to each test.
> This is because the only difference between the cda request calls for a POST /laa_references is the request body and not the endpoint.This meant that tests were failing because it wasn't matching the correct mock route.

## Link to Jira Ticket

- [AAC-495](https://dsdmoj.atlassian.net/browse/AAC-495)

**To Note:**
~~No Postman tests on this endpoint~~
**Added a Postman test to expect a 422 http status code** 
Couldn't do a 202 because It fails as in order to link a case, it must be first unlinked. Creating a postman test for a successful link will mean it'll be coupled to the PATCH endpoint or expected data in CDA/HMCTS mock.

## Screenshots or test evidence if applicable

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/25043924/159239060-ea51788e-e75d-46e0-ad27-37afa0ff30fb.png">