### PR TITLE
AAC-546 - Add ASN and NI to defendants search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.10-alpine
 
 WORKDIR /code
 
-RUN apk --no-cache add --upgrade gcc \
+RUN apk --update-cache upgrade \
+&& apk --no-cache add --upgrade gcc \
     musl-dev \
     build-base \
     expat

--- a/laa_court_data_api_app/routers/defendants.py
+++ b/laa_court_data_api_app/routers/defendants.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter
@@ -15,10 +14,12 @@ router = APIRouter()
 
 
 @router.get('/v2/defendants', response_model=DefendantsResponse, status_code=200)
-async def get_defendants(urn: Optional[str] = None,
-                         name: Optional[str] = None,
-                         dob: Optional[str] = None,
-                         uuid: Optional[UUID] = None):
+async def get_defendants(urn: str | None = None,
+                         name: str | None = None,
+                         dob: str | None = None,
+                         uuid: UUID | None = None,
+                         asn: str | None = None,
+                         nino: str | None = None):
     client = CourtDataAdaptorClient()
     logger.info("Calling_Defendants_Get_Endpoint")
 
@@ -33,6 +34,14 @@ async def get_defendants(urn: Optional[str] = None,
         logging.info(f"Defendants_Get_Urn_{urn}")
         cda_response = await client.get("/api/internal/v2/prosecution_cases",
                                         params={"filter[prosecution_case_reference]": urn})
+    elif asn:
+        logging.info(f"Defendants_Get_Urn_{asn}")
+        cda_response = await client.get("/api/internal/v2/prosecution_cases",
+                                        params={"filter[arrest_summons_number]": asn})
+    elif nino:
+        logging.info(f"Defendants_Get_Urn_{nino}")
+        cda_response = await client.get("/api/internal/v2/prosecution_cases",
+                                        params={"filter[national_insurance_number]": nino})
     else:
         logger.error("Invalid_Defendant_Search")
         return Response(status_code=400)

--- a/laa_court_data_api_app/routers/defendants.py
+++ b/laa_court_data_api_app/routers/defendants.py
@@ -35,11 +35,11 @@ async def get_defendants(urn: str | None = None,
         cda_response = await client.get("/api/internal/v2/prosecution_cases",
                                         params={"filter[prosecution_case_reference]": urn})
     elif asn:
-        logging.info(f"Defendants_Get_asn_{asn}")
+        logging.info(f"Defendants_Get_Asn_{asn}")
         cda_response = await client.get("/api/internal/v2/prosecution_cases",
                                         params={"filter[arrest_summons_number]": asn})
     elif nino:
-        logging.info(f"Defendants_Get_nino_{nino}")
+        logging.info(f"Defendants_Get_Nino_{nino}")
         cda_response = await client.get("/api/internal/v2/prosecution_cases",
                                         params={"filter[national_insurance_number]": nino})
     else:

--- a/laa_court_data_api_app/routers/defendants.py
+++ b/laa_court_data_api_app/routers/defendants.py
@@ -35,11 +35,11 @@ async def get_defendants(urn: str | None = None,
         cda_response = await client.get("/api/internal/v2/prosecution_cases",
                                         params={"filter[prosecution_case_reference]": urn})
     elif asn:
-        logging.info(f"Defendants_Get_Urn_{asn}")
+        logging.info(f"Defendants_Get_asn_{asn}")
         cda_response = await client.get("/api/internal/v2/prosecution_cases",
                                         params={"filter[arrest_summons_number]": asn})
     elif nino:
-        logging.info(f"Defendants_Get_Urn_{nino}")
+        logging.info(f"Defendants_Get_nino_{nino}")
         cda_response = await client.get("/api/internal/v2/prosecution_cases",
                                         params={"filter[national_insurance_number]": nino})
     else:

--- a/postman/collections/defendants.postman_collection.json
+++ b/postman/collections/defendants.postman_collection.json
@@ -263,7 +263,7 @@
 					}
 				],
 				"url": {
-					"raw": "{{BaseUrl}}/v2/defendants?urn={{Nino}}",
+					"raw": "{{BaseUrl}}/v2/defendants?nino={{Nino}}",
 					"host": [
 						"{{BaseUrl}}"
 					],
@@ -273,7 +273,7 @@
 					],
 					"query": [
 						{
-							"key": "urn",
+							"key": "nino",
 							"value": "{{Nino}}"
 						}
 					]
@@ -318,7 +318,7 @@
 					}
 				],
 				"url": {
-					"raw": "{{BaseUrl}}/v2/defendants?urn={{ASN}}",
+					"raw": "{{BaseUrl}}/v2/defendants?asn={{ASN}}",
 					"host": [
 						"{{BaseUrl}}"
 					],
@@ -328,7 +328,7 @@
 					],
 					"query": [
 						{
-							"key": "urn",
+							"key": "asn",
 							"value": "{{ASN}}"
 						}
 					]

--- a/postman/collections/defendants.postman_collection.json
+++ b/postman/collections/defendants.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cda7fa59-9b38-4238-bfad-05bab5ce12f9",
+		"_postman_id": "53327275-5679-45a8-bbfb-cf5ee7a39ced",
 		"name": "Defendants",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -220,6 +220,116 @@
 						{
 							"key": "$uuid",
 							"value": "{{Uuid}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Defendants by National Insurance Number",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Defendants Included\", function () {",
+							"    var json_data = pm.response.json();",
+							"    pm.expect(json_data).to.haveOwnProperty('defendant_summaries');",
+							"});",
+							"",
+							"pm.test(\"Defendants is Array\", function () {",
+							"    var json_data = pm.response.json();",
+							"    var defendants = json_data.defendant_summaries;",
+							"    pm.expect(defendants).to.be.a('array');",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Basic {{Username}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{BaseUrl}}/v2/defendants?urn={{Nino}}",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"v2",
+						"defendants"
+					],
+					"query": [
+						{
+							"key": "urn",
+							"value": "{{Nino}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Defendants by Arrest Summons Number",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Defendants Included\", function () {",
+							"    var json_data = pm.response.json();",
+							"    pm.expect(json_data).to.haveOwnProperty('defendant_summaries');",
+							"});",
+							"",
+							"pm.test(\"Defendants is Array\", function () {",
+							"    var json_data = pm.response.json();",
+							"    var defendants = json_data.defendant_summaries;",
+							"    pm.expect(defendants).to.be.a('array');",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Basic {{Username}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{BaseUrl}}/v2/defendants?urn={{ASN}}",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"v2",
+						"defendants"
+					],
+					"query": [
+						{
+							"key": "urn",
+							"value": "{{ASN}}"
 						}
 					]
 				}

--- a/postman/environments/dev.postman_environment.json
+++ b/postman/environments/dev.postman_environment.json
@@ -60,9 +60,21 @@
 			"value": "1234567",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "Nino",
+			"value": "HX685369B",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ASN",
+			"value": "FPV3XYUJNPIB",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-03-15T21:15:30.797Z",
-	"_postman_exported_using": "Postman/9.14.12"
+	"_postman_exported_at": "2022-03-23T20:23:17.203Z",
+	"_postman_exported_using": "Postman/9.14.13"
 }

--- a/postman/environments/local.postman_environment.json
+++ b/postman/environments/local.postman_environment.json
@@ -61,9 +61,21 @@
 			"value": "1234567",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "Nino",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ASN",
+			"value": "FPV3XYUJNPIB",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-03-15T21:16:26.251Z",
-	"_postman_exported_using": "Postman/9.14.12"
+	"_postman_exported_at": "2022-03-23T20:23:07.340Z",
+	"_postman_exported_using": "Postman/9.14.13"
 }

--- a/postman/environments/local.postman_environment.json
+++ b/postman/environments/local.postman_environment.json
@@ -64,7 +64,7 @@
 		},
 		{
 			"key": "Nino",
-			"value": "",
+			"value": "HX685369B",
 			"type": "default",
 			"enabled": true
 		},
@@ -76,6 +76,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-03-23T20:23:07.340Z",
+	"_postman_exported_at": "2022-03-24T13:11:13.981Z",
 	"_postman_exported_using": "Postman/9.14.13"
 }

--- a/postman/environments/production.postman_environment.json
+++ b/postman/environments/production.postman_environment.json
@@ -43,9 +43,21 @@
 			"value": "1234567",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "Nino",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ASN",
+			"value": "",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-03-15T21:16:41.073Z",
-	"_postman_exported_using": "Postman/9.14.12"
+	"_postman_exported_at": "2022-03-23T20:22:56.825Z",
+	"_postman_exported_using": "Postman/9.14.13"
 }

--- a/postman/environments/staging.postman_environment.json
+++ b/postman/environments/staging.postman_environment.json
@@ -61,9 +61,21 @@
 			"value": "1234567",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "Nino",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ASN",
+			"value": "",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-03-15T21:16:49.546Z",
-	"_postman_exported_using": "Postman/9.14.12"
+	"_postman_exported_at": "2022-03-23T20:22:46.543Z",
+	"_postman_exported_using": "Postman/9.14.13"
 }

--- a/postman/environments/uat.postman_environment.json
+++ b/postman/environments/uat.postman_environment.json
@@ -61,9 +61,21 @@
 			"value": "1234567",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "Nino",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ASN",
+			"value": "",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-03-15T21:16:56.738Z",
-	"_postman_exported_using": "Postman/9.14.12"
+	"_postman_exported_at": "2022-03-23T20:22:22.262Z",
+	"_postman_exported_using": "Postman/9.14.13"
 }

--- a/test/routers/defendants_test.py
+++ b/test/routers/defendants_test.py
@@ -273,3 +273,161 @@ def test_defendants_by_urn_returns_none(mock_settings, mock_cda_settings, overri
     assert response.status_code == 424
     assert response.content == b''
     assert mock_cda_client["failed_token_endpoint"].called
+
+
+# Search defendant by asn
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_asn_returns_ok(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                      mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?asn=pass")
+
+    assert response.status_code == 200
+    assert mock_cda_client["pass_asn_route"].called
+    model = DefendantsResponse(**response.json())
+    assert len(model.defendant_summaries) == 1
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_asn_returns_bad_request(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                               mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?asn=fail")
+
+    assert response.status_code == 400
+    assert mock_cda_client["fail_asn_route"].called
+    assert response.content == b''
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_asn_returns_not_found(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                             mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?asn=notfound")
+
+    assert response.status_code == 404
+    assert mock_cda_client["notfound_asn_route"].called
+    assert response.content == b''
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_asn_returns_server_error(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                                mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?asn=exception")
+
+    assert response.status_code == 424
+    assert mock_cda_client["exception_asn_route"].called
+    assert response.content == b''
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_asn_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                        mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+                                                 cda_uid="12345")
+    response = client.get("/v2/defendants?asn=exception")
+
+    assert response.status_code == 424
+    assert response.content == b''
+    assert mock_cda_client["failed_token_endpoint"].called
+
+
+# Search defendant by nino
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_nino_returns_ok(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                       mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?nino=pass")
+
+    assert response.status_code == 200
+    assert mock_cda_client["pass_nino_route"].called
+    model = DefendantsResponse(**response.json())
+    assert len(model.defendant_summaries) == 1
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_nino_returns_bad_request(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                                mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?nino=fail")
+
+    assert response.status_code == 400
+    assert mock_cda_client["fail_nino_route"].called
+    assert response.content == b''
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_nino_returns_not_found(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                              mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?nino=notfound")
+
+    assert response.status_code == 404
+    assert mock_cda_client["notfound_nino_route"].called
+    assert response.content == b''
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_nino_returns_server_error(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                                 mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = override_get_cda_settings
+    response = client.get("/v2/defendants?nino=exception")
+
+    assert response.status_code == 424
+    assert mock_cda_client["exception_nino_route"].called
+    assert response.content == b''
+
+
+@patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
+@patch('laa_court_data_api_app.internal.court_data_adaptor_client.CourtDataAdaptorClient.settings',
+       new_callable=PropertyMock)
+def test_defendants_by_nino_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
+                                         mock_cda_client):
+    OauthClient().token = None
+    mock_settings.return_value = override_get_cda_settings
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+                                                 cda_uid="12345")
+    response = client.get("/v2/defendants?nino=exception")
+
+    assert response.status_code == 424
+    assert response.content == b''
+    assert mock_cda_client["failed_token_endpoint"].called

--- a/test/routers/fixtures.py
+++ b/test/routers/fixtures.py
@@ -118,6 +118,56 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
             name="exception_urn_uuid_route")
         exception_urn_uuid_route.return_value = Response(500)
 
+        pass_asn_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[arrest_summons_number]": "pass"},
+            name="pass_asn_route")
+        pass_asn_route.return_value = Response(200, json=get_prosecution_case_results.dict())
+
+        fail_asn_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[arrest_summons_number]": "fail"},
+            name="fail_asn_route")
+        fail_asn_route.return_value = Response(400)
+
+        notfound_asn_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[arrest_summons_number]": "notfound"},
+            name="notfound_asn_route"
+        )
+        notfound_asn_route.return_value = Response(404)
+
+        exception_asn_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[arrest_summons_number]": "exception"},
+            name="exception_asn_route")
+        exception_asn_route.return_value = Response(500)
+
+        pass_nino_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[national_insurance_number]": "pass"},
+            name="pass_nino_route")
+        pass_nino_route.return_value = Response(200, json=get_prosecution_case_results.dict())
+
+        fail_nino_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[national_insurance_number]": "fail"},
+            name="fail_nino_route")
+        fail_nino_route.return_value = Response(400)
+
+        notfound_nino_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[national_insurance_number]": "notfound"},
+            name="notfound_nino_route"
+        )
+        notfound_nino_route.return_value = Response(404)
+
+        exception_nino_route = respx_mock.get(
+            "http://test-url/api/internal/v2/prosecution_cases",
+            params={"filter[national_insurance_number]": "exception"},
+            name="exception_nino_route")
+        exception_nino_route.return_value = Response(500)
+
         # /hearing
         pass_hearing_route = respx_mock.get(
             "http://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000000",


### PR DESCRIPTION
## Description of change

We need the additional search options of NI and ASN on the defendants endpoint to provide feature parity. This adds this in with testing.

## Link to Jira Ticket

- [AAC-546](https://dsdmoj.atlassian.net/browse/AAC-546)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->

## Notes

Test data is hard to come by, im not sure if this is working from a CDA/CP point of view. However it is implement as specified