### PR TITLE
Aac 558 update unlinking endpoint

### DIFF
--- a/laa_court_data_api_app/routers/laa_references.py
+++ b/laa_court_data_api_app/routers/laa_references.py
@@ -31,7 +31,7 @@ responses = {
 }
 
 
-@router.patch("/v2/laa_references/{defendant_id}", status_code=202, responses=responses)
+@router.patch("/v2/laa_references/{defendant_id}/", status_code=202, responses=responses)
 async def patch_maat_unlink(defendant_id: str, request: ExternalPatchRequest):
     logger.info(f"Calling_Maat_Patch_{defendant_id}")
     client = CourtDataAdaptorClient()

--- a/postman/collections/laa_references.postman_collection.json
+++ b/postman/collections/laa_references.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0be07611-470e-4a83-8652-7748e9c42db5",
+		"_postman_id": "a9a4f1e9-c270-4710-9866-4446db84d8cd",
 		"name": "Laa References",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -96,14 +96,15 @@
 					}
 				},
 				"url": {
-					"raw": "{{BaseUrl}}/v2/laa_references/{{DefendantId}}",
+					"raw": "{{BaseUrl}}/v2/laa_references/{{DefendantId}}/",
 					"host": [
 						"{{BaseUrl}}"
 					],
 					"path": [
 						"v2",
 						"laa_references",
-						"{{DefendantId}}"
+						"{{DefendantId}}",
+						""
 					]
 				}
 			},

--- a/test/routers/fixtures.py
+++ b/test/routers/fixtures.py
@@ -207,22 +207,22 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
 
         # patch /laa_references
         pass_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222/",
             name="laa_references_patch_pass_route")
         pass_patch_maat.return_value = Response(202)
 
         fail_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223/",
             name="laa_references_patch_fail_route")
         fail_patch_maat.return_value = Response(400, json={"unlink_other_reason_text": ["must be absent"]})
 
         not_found_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224/",
             name="laa_references_patch_not_found_route")
         not_found_patch_maat.return_value = Response(404)
 
         unprocessable_entity_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225/",
             name="laa_references_patch_unprocessable_entity_route")
         unprocessable_entity_patch_maat.return_value = Response(422, json={"error": "Contract failed with: {"
                                                                                     ":maat_reference=>[\"3141592 has "
@@ -230,7 +230,7 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
                                                                                     "against Maat application.\"]}"})
 
         server_error_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226/",
             name="laa_references_patch_server_error_route")
         server_error_patch_maat.return_value = Response(424)
 

--- a/test/routers/fixtures.py
+++ b/test/routers/fixtures.py
@@ -207,22 +207,22 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
 
         # patch /laa_references
         pass_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222/",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
             name="laa_references_patch_pass_route")
         pass_patch_maat.return_value = Response(202)
 
         fail_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223/",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223",
             name="laa_references_patch_fail_route")
         fail_patch_maat.return_value = Response(400, json={"unlink_other_reason_text": ["must be absent"]})
 
         not_found_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224/",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224",
             name="laa_references_patch_not_found_route")
         not_found_patch_maat.return_value = Response(404)
 
         unprocessable_entity_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225/",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225",
             name="laa_references_patch_unprocessable_entity_route")
         unprocessable_entity_patch_maat.return_value = Response(422, json={"error": "Contract failed with: {"
                                                                                     ":maat_reference=>[\"3141592 has "
@@ -230,7 +230,7 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
                                                                                     "against Maat application.\"]}"})
 
         server_error_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226/",
+            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226",
             name="laa_references_patch_server_error_route")
         server_error_patch_maat.return_value = Response(424)
 

--- a/test/routers/laa_references/patch_test.py
+++ b/test/routers/laa_references/patch_test.py
@@ -18,7 +18,7 @@ def test_laa_references_patch_returns_accepted(mock_settings, mock_cda_settings,
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222/",
                             json=LaaReferencesPatchRequest().dict())
 
     assert response.status_code == 202
@@ -35,7 +35,7 @@ def test_laa_references_patch_returns_bad_request(mock_settings, mock_cda_settin
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223",
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223/",
                             json=LaaReferencesPatchRequest().dict())
 
     assert response.status_code == 400
@@ -52,7 +52,7 @@ def test_laa_references_patch_returns_not_found(mock_settings, mock_cda_settings
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224",
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224/",
                             json=LaaReferencesPatchRequest().dict())
 
     assert response.status_code == 404
@@ -69,7 +69,7 @@ def test_laa_references_patch_returns_unprocessable_entity(mock_settings, mock_c
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225",
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225/",
                             json=LaaReferencesPatchRequest().dict())
 
     assert response.status_code == 422
@@ -87,7 +87,7 @@ def test_laa_references_patch_returns_server_error(mock_settings, mock_cda_setti
     mock_settings.return_value = override_get_cda_settings
     mock_cda_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226",
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226/",
                             json=LaaReferencesPatchRequest().dict())
 
     assert response.status_code == 424
@@ -105,7 +105,7 @@ def test_laa_references_patch_returns_none(mock_settings, mock_cda_settings, ove
                                                  cda_uid="12345")
     mock_settings.return_value = override_get_cda_settings
 
-    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
+    response = client.patch("/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222/",
                             json=LaaReferencesPatchRequest().dict())
 
     assert response.status_code == 424


### PR DESCRIPTION
## Description of change

Added trailing slash to Defendant patch endpoint (unlinking)

This is needed as implementing a [PATCH request via Active Resource](https://github.com/rails/activeresource/blob/main/lib/active_resource/custom_methods.rb#L107) adds a trailing slash at the end of the request, need to change CD API to work in the same way 

## Link to Jira Ticket

- [AAC-558 Implement MAAT Unlinking against CDAPI](https://dsdmoj.atlassian.net/browse/AAC-558)
