### PR TITLE
Add prosecution_case_reference to hearing_summaries

### DIFF
--- a/laa_court_data_api_app/models/hearing_summaries/hearing_summaries_response.py
+++ b/laa_court_data_api_app/models/hearing_summaries/hearing_summaries_response.py
@@ -5,5 +5,6 @@ from laa_court_data_api_app.models.hearing_summaries.hearing_summary import Hear
 
 
 class HearingSummariesResponse(BaseModel):
+    prosecution_case_reference: str | None
     hearing_summaries: list[HearingSummary] | None
     overall_defendants: list[Defendants]

--- a/laa_court_data_api_app/routers/hearing_summaries.py
+++ b/laa_court_data_api_app/routers/hearing_summaries.py
@@ -31,7 +31,7 @@ async def get_hearing_summaries(urn: str):
             logger.info("Prosecution_Case_Endpoint_Returned_Success")
             prosecution_case_results = ProsecutionCasesResults(**cda_response.json())
             summaries = map_hearing_summaries(prosecution_case_results.results)
-             logger.info("Hearing_Summaries_To_Show", count=len(summaries))
+            logger.info("Hearing_Summaries_To_Show", count=len(summaries))
             return HearingSummariesResponse(prosecution_case_reference=urn,
                                             hearing_summaries=summaries,
                                             overall_defendants=map_defendant_list(prosecution_case_results.results))

--- a/laa_court_data_api_app/routers/hearing_summaries.py
+++ b/laa_court_data_api_app/routers/hearing_summaries.py
@@ -33,7 +33,8 @@ async def get_hearing_summaries(urn: str):
             prosecution_case_results = ProsecutionCasesResults(**cda_response.json())
             summaries = map_hearing_summaries(prosecution_case_results.results)
             logging.info(f"Hearing_Summaries_To_Show: {summaries.count}")
-            return HearingSummariesResponse(hearing_summaries=summaries,
+            return HearingSummariesResponse(prosecution_case_reference=urn,
+                                            hearing_summaries=summaries,
                                             overall_defendants=map_defendant_list(prosecution_case_results.results))
         case 400:
             logging.info("Prosecution_Case_Endpoint_Validation_Failed")


### PR DESCRIPTION
## Description of change
Modified hearing_summaries_response model
Added logic to include prosecution_case_reference as urn (from path)

## Link to Jira Ticket

- [AAC-617 Add Prosecution Case Reference to HearingSummaries API Endpoint](https://dsdmoj.atlassian.net/browse/AAC-617)

## Screenshots or test evidence if applicable
<img width="533" alt="image" src="https://user-images.githubusercontent.com/26544538/167427843-a38c8b50-b66a-4961-a716-742a8979b951.png">

