### PR TITLE
Update tests to use HTTPS

### DIFF
--- a/test/internal/internal_fixtures.py
+++ b/test/internal/internal_fixtures.py
@@ -11,7 +11,7 @@ from laa_court_data_api_app.models.token_response import TokenResponse
 
 @pytest.fixture(scope="module")
 def get_cda_env_vars():
-    return CdaSettings(cda_endpoint="http://test-url/", cda_uid="12345", cda_secret="123454321")
+    return CdaSettings(cda_endpoint="https://test-url/", cda_uid="12345", cda_secret="123454321")
 
 
 @pytest.fixture(scope="module")
@@ -29,7 +29,7 @@ def get_new_token_response():
 
 @pytest.fixture(scope="function")
 def mock_cda_client(get_new_token_response, response_code):
-    with respx.mock(base_url="http://test-url/", assert_all_called=False) as respx_mock:
+    with respx.mock(base_url="https://test-url/", assert_all_called=False) as respx_mock:
         get_route = respx_mock.get("/get/", name="get_endpoint")
         get_route.return_value = Response(response_code, json=[])
         get_exception = respx_mock.get("/get/exception", name="get_exception_endpoint")

--- a/test/internal/oauth_client_test.py
+++ b/test/internal/oauth_client_test.py
@@ -6,7 +6,7 @@ from test.internal.internal_fixtures import *
 
 class TestOAuthClient:
     @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
-    @pytest.mark.respx(base_url="http://test-url/")
+    @pytest.mark.respx(base_url="https://test-url/")
     async def test_retrieve_token_returns_correct_value(self, mock_settings, respx_mock, get_cda_env_vars):
         mock_settings.return_value = get_cda_env_vars
         respx_mock.post("/oauth/token").mock(return_value=httpx.Response(status_code=200,
@@ -23,7 +23,7 @@ class TestOAuthClient:
         assert response.created_at == 1643981187
 
     @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
-    @pytest.mark.respx(base_url="http://test-url/")
+    @pytest.mark.respx(base_url="https://test-url/")
     async def test_retrieve_token_stores_token(self, mock_settings, respx_mock, get_cda_env_vars):
         mock_settings.return_value = get_cda_env_vars
         respx_mock.post("/oauth/token").mock(return_value=httpx.Response(status_code=200,
@@ -40,7 +40,7 @@ class TestOAuthClient:
         assert OauthClient().token.created_at == 1643981187
 
     @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
-    @pytest.mark.respx(base_url="http://test-url/")
+    @pytest.mark.respx(base_url="https://test-url/")
     async def test_retrieve_token_calls_endpoint(self, mock_settings, respx_mock, get_cda_env_vars):
         mock_settings.return_value = get_cda_env_vars
         route = respx_mock.post("/oauth/token").mock(return_value=httpx.Response(status_code=200,
@@ -54,7 +54,7 @@ class TestOAuthClient:
         assert route.called
 
     @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
-    @pytest.mark.respx(base_url="http://test-url/")
+    @pytest.mark.respx(base_url="https://test-url/")
     async def test_retrieve_token_calls_property(self, mock_settings, respx_mock, get_cda_env_vars,
                                                  get_new_token_response):
         mock_settings.return_value = get_cda_env_vars
@@ -72,7 +72,7 @@ class TestOAuthClient:
         assert response.access_token == client.token.access_token
 
     @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
-    @pytest.mark.respx(base_url="http://test-url/")
+    @pytest.mark.respx(base_url="https://test-url/")
     async def test_retrieve_token_calls_property(self, mock_settings, respx_mock, get_cda_env_vars,
                                                  get_expired_token_response):
         mock_settings.return_value = get_cda_env_vars
@@ -90,7 +90,7 @@ class TestOAuthClient:
         assert response.access_token == "123456"
 
     @patch('laa_court_data_api_app.internal.oauth_client.OauthClient.settings', new_callable=PropertyMock)
-    @pytest.mark.respx(base_url="http://test-url/")
+    @pytest.mark.respx(base_url="https://test-url/")
     async def test_retrieve_token_calls_property(self, mock_settings, respx_mock, get_cda_env_vars):
         mock_settings.return_value = get_cda_env_vars
         respx_mock.post("/oauth/token").mock(return_value=httpx.Response(status_code=500))

--- a/test/routers/defendants_test.py
+++ b/test/routers/defendants_test.py
@@ -94,7 +94,7 @@ def test_defendants_by_name_dob_returns_none(mock_settings, mock_cda_settings, o
                                              mock_cda_client):
     OauthClient().token = None
     mock_settings.return_value = override_get_cda_settings
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     response = client.get("/v2/defendants?name=exception&dob=exception")
 
@@ -173,7 +173,7 @@ def test_defendants_by_urn_uuid_returns_none(mock_settings, mock_cda_settings, o
                                              mock_cda_client):
     OauthClient().token = None
     mock_settings.return_value = override_get_cda_settings
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     response = client.get("/v2/defendants?urn=exception&uuid=22d2222c-22ff-22ec-b222-2222ac222222")
 
@@ -266,7 +266,7 @@ def test_defendants_by_urn_returns_none(mock_settings, mock_cda_settings, overri
                                         mock_cda_client):
     OauthClient().token = None
     mock_settings.return_value = override_get_cda_settings
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     response = client.get("/v2/defendants?urn=exception")
 
@@ -345,7 +345,7 @@ def test_defendants_by_asn_returns_none(mock_settings, mock_cda_settings, overri
                                         mock_cda_client):
     OauthClient().token = None
     mock_settings.return_value = override_get_cda_settings
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     response = client.get("/v2/defendants?asn=exception")
 
@@ -424,7 +424,7 @@ def test_defendants_by_nino_returns_none(mock_settings, mock_cda_settings, overr
                                          mock_cda_client):
     OauthClient().token = None
     mock_settings.return_value = override_get_cda_settings
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     response = client.get("/v2/defendants?nino=exception")
 

--- a/test/routers/fixtures.py
+++ b/test/routers/fixtures.py
@@ -20,7 +20,7 @@ from laa_court_data_api_app.models.token_response import TokenResponse
 
 @pytest.fixture()
 def override_get_cda_settings():
-    return CdaSettings(cda_secret="12345", cda_uid="12345", cda_endpoint="http://test-url/")
+    return CdaSettings(cda_secret="12345", cda_uid="12345", cda_endpoint="https://test-url/")
 
 
 @pytest.fixture()
@@ -52,42 +52,42 @@ def get_hearing_results():
 def mock_cda_client(get_new_token_response, get_prosecution_case_results,
                     get_hearing_results, get_hearing_events_results):
     with respx.mock(assert_all_called=False) as respx_mock:
-        get_route = respx_mock.post("http://test-url/oauth/token", name="token_endpoint")
+        get_route = respx_mock.post("https://test-url/oauth/token", name="token_endpoint")
         get_route.return_value = Response(200, json=get_new_token_response.dict())
 
-        failed_token_route = respx_mock.post("http://failed-test-url/oauth/token", name="failed_token_endpoint")
+        failed_token_route = respx_mock.post("https://failed-test-url/oauth/token", name="failed_token_endpoint")
         failed_token_route.return_value = Response(500)
 
-        pass_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        pass_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                     params={"filter[prosecution_case_reference]": "pass"}, name="pass_route")
         pass_route.return_value = Response(200, json=get_prosecution_case_results.dict())
-        fail_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        fail_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                     params={"filter[prosecution_case_reference]": "fail"}, name="fail_route")
         fail_route.return_value = Response(400)
-        notfound_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        notfound_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                         params={"filter[prosecution_case_reference]": "notfound"},
                                         name="notfound_route")
         notfound_route.return_value = Response(404)
-        exception_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        exception_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                          params={"filter[prosecution_case_reference]": "exception"},
                                          name="exception_route")
         exception_route.return_value = Response(500)
 
         # /defendants by name and date of birth
-        pass_name_dob_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        pass_name_dob_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                              params={"filter[name]": "pass", "filter[date_of_birth]": "pass"},
                                              name="pass_name_dob_route")
         pass_name_dob_route.return_value = Response(200, json=get_prosecution_case_results.dict())
-        fail_name_dob_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        fail_name_dob_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                              params={"filter[name]": "fail", "filter[date_of_birth]": "fail"},
                                              name="fail_name_dob_route")
         fail_name_dob_route.return_value = Response(400)
-        notfound_name_dob_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        notfound_name_dob_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                                  params={"filter[name]": "notfound",
                                                          "filter[date_of_birth]": "notfound"},
                                                  name="notfound_name_dob_route")
         notfound_name_dob_route.return_value = Response(404)
-        exception_name_dob_route = respx_mock.get("http://test-url/api/internal/v2/prosecution_cases",
+        exception_name_dob_route = respx_mock.get("https://test-url/api/internal/v2/prosecution_cases",
                                                   params={"filter[name]": "exception",
                                                           "filter[date_of_birth]": "exception"},
                                                   name="exception_name_dob_route")
@@ -95,138 +95,138 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
 
         # /defendants by urn and uuid
         pass_urn_uuid_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases/pass/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
+            "https://test-url/api/internal/v2/prosecution_cases/pass/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
             name="pass_urn_uuid_route")
         pass_urn_uuid_route.return_value = Response(200, json=get_prosecution_case_results.dict())
 
         fail_urn_uuid_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases/fail/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
+            "https://test-url/api/internal/v2/prosecution_cases/fail/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
             name="fail_urn_uuid_route")
         fail_urn_uuid_route.return_value = Response(400)
 
         notfound_urn_uuid_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases/404/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
+            "https://test-url/api/internal/v2/prosecution_cases/404/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
             name="notfound_urn_uuid_route"
         )
         notfound_urn_uuid_route.return_value = Response(404)
 
         exception_urn_uuid_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases/error/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
+            "https://test-url/api/internal/v2/prosecution_cases/error/defendants/22d2222c-22ff-22ec-b222-2222ac222222",
             name="exception_urn_uuid_route")
         exception_urn_uuid_route.return_value = Response(500)
 
         pass_asn_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[arrest_summons_number]": "pass"},
             name="pass_asn_route")
         pass_asn_route.return_value = Response(200, json=get_prosecution_case_results.dict())
 
         fail_asn_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[arrest_summons_number]": "fail"},
             name="fail_asn_route")
         fail_asn_route.return_value = Response(400)
 
         notfound_asn_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[arrest_summons_number]": "notfound"},
             name="notfound_asn_route"
         )
         notfound_asn_route.return_value = Response(404)
 
         exception_asn_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[arrest_summons_number]": "exception"},
             name="exception_asn_route")
         exception_asn_route.return_value = Response(500)
 
         pass_nino_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[national_insurance_number]": "pass"},
             name="pass_nino_route")
         pass_nino_route.return_value = Response(200, json=get_prosecution_case_results.dict())
 
         fail_nino_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[national_insurance_number]": "fail"},
             name="fail_nino_route")
         fail_nino_route.return_value = Response(400)
 
         notfound_nino_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[national_insurance_number]": "notfound"},
             name="notfound_nino_route"
         )
         notfound_nino_route.return_value = Response(404)
 
         exception_nino_route = respx_mock.get(
-            "http://test-url/api/internal/v2/prosecution_cases",
+            "https://test-url/api/internal/v2/prosecution_cases",
             params={"filter[national_insurance_number]": "exception"},
             name="exception_nino_route")
         exception_nino_route.return_value = Response(500)
 
         # /hearing
         pass_hearing_route = respx_mock.get(
-            "http://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000000",
+            "https://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000000",
             params={'sitting_day': '01-04-2021'},
             name="pass_hearing_route")
         pass_hearing_route.return_value = Response(200, json=get_hearing_results.dict())
         fail_hearing_route = respx_mock.get(
-            "http://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000001",
+            "https://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000001",
             params={'sitting_day': '01-04-2021'},
             name="fail_hearing_route")
         fail_hearing_route.return_value = Response(400)
         notfound_hearing_route = respx_mock.get(
-            "http://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000002",
+            "https://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000002",
             params={'sitting_day': '01-04-2021'},
             name="notfound_hearing_route")
         notfound_hearing_route.return_value = Response(404)
         exception_hearing_route = respx_mock.get(
-            "http://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000003",
+            "https://test-url/api/internal/v2/hearing_results/00d0000c-00ff-00ec-b000-0000ac000003",
             params={'sitting_day': '01-04-2021'},
             name="exception_hearing_route")
         exception_hearing_route.return_value = Response(500)
 
         # /hearing_events by date
         hearing_events_pass = respx_mock.get(
-            "http://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/pass",
+            "https://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/pass",
             name="pass_hearing_events_route")
         hearing_events_pass.return_value = Response(200, json=get_hearing_events_results.dict())
 
         fail_hearing_events_uuid_route = respx_mock.get(
-            "http://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/fail",
+            "https://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/fail",
             name="fail_hearing_events_route")
         fail_hearing_events_uuid_route.return_value = Response(400)
 
         notfound_hearing_events_uuid_route = respx_mock.get(
-            "http://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/notfound",
+            "https://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/notfound",
             name="notfound_hearing_events_uuid_route"
         )
         notfound_hearing_events_uuid_route.return_value = Response(404)
 
         exception_urn_uuid_route = respx_mock.get(
-            "http://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/exception",
+            "https://test-url/api/internal/v2/hearings/22d2222c-22ff-22ec-b222-2222ac222222/event_log/exception",
             name="exception_hearing_events_uuid_route")
         exception_urn_uuid_route.return_value = Response(500)
 
         # patch /laa_references
         pass_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
+            "https://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222222",
             name="laa_references_patch_pass_route")
         pass_patch_maat.return_value = Response(202)
 
         fail_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223",
+            "https://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222223",
             name="laa_references_patch_fail_route")
         fail_patch_maat.return_value = Response(400, json={"unlink_other_reason_text": ["must be absent"]})
 
         not_found_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224",
+            "https://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222224",
             name="laa_references_patch_not_found_route")
         not_found_patch_maat.return_value = Response(404)
 
         unprocessable_entity_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225",
+            "https://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222225",
             name="laa_references_patch_unprocessable_entity_route")
         unprocessable_entity_patch_maat.return_value = Response(422, json={"error": "Contract failed with: {"
                                                                                     ":maat_reference=>[\"3141592 has "
@@ -234,32 +234,32 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
                                                                                     "against Maat application.\"]}"})
 
         server_error_patch_maat = respx_mock.patch(
-            "http://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226",
+            "https://test-url/api/internal/v2/laa_references/22d2222c-22ff-22ec-b222-2222ac222226",
             name="laa_references_patch_server_error_route")
         server_error_patch_maat.return_value = Response(424)
 
         # post /laa_references
 
         pass_post_maat = respx_mock.post(
-            "http://test-url/api/internal/v2/laa_references/",
+            "https://test-url/api/internal/v2/laa_references/",
             name="laa_references_post_pass_route",
             data=b'{"laa_reference": {"user_name": "pass-u", "defendant_id": null, "maat_reference": 1234567}}')
         pass_post_maat.return_value = Response(202)
 
         fail_post_maat = respx_mock.post(
-            "http://test-url/api/internal/v2/laa_references/",
+            "https://test-url/api/internal/v2/laa_references/",
             name="laa_references_post_fail_route",
             json__laa_reference__user_name="fail-u")
         fail_post_maat.return_value = Response(400, json={"unlink_other_reason_text": ["must be absent"]})
 
         not_found_post_maat = respx_mock.post(
-            "http://test-url/api/internal/v2/laa_references/",
+            "https://test-url/api/internal/v2/laa_references/",
             name="laa_references_post_not_found_route",
             json__laa_reference__user_name="notfound-u")
         not_found_post_maat.return_value = Response(404)
 
         unprocessable_entity_post_maat = respx_mock.post(
-            "http://test-url/api/internal/v2/laa_references/",
+            "https://test-url/api/internal/v2/laa_references/",
             name="laa_references_post_unprocessable_entity_route",
             json__laa_reference__user_name="unprocessable-u")
         unprocessable_entity_post_maat.return_value = Response(422, json={"error": "Contract failed with: {"
@@ -268,7 +268,7 @@ def mock_cda_client(get_new_token_response, get_prosecution_case_results,
                                                                                    "against Maat application.\"]}"})
 
         server_error_post_maat = respx_mock.post(
-            "http://test-url/api/internal/v2/laa_references/",
+            "https://test-url/api/internal/v2/laa_references/",
             name="laa_references_post_server_error_route",
             json__laa_reference__user_name="servererror-u")
         server_error_post_maat.return_value = Response(424)

--- a/test/routers/hearing_events_test.py
+++ b/test/routers/hearing_events_test.py
@@ -80,7 +80,7 @@ def test_hearing_events_returns_server_error(mock_settings, mock_cda_settings, o
 def test_hearing_events_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
                                      mock_cda_client):
     OauthClient().token = None
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     mock_settings.return_value = override_get_cda_settings
     response = client.get("/v2/hearing_events/22d2222c-22ff-22ec-b222-2222ac222222?date=pass")

--- a/test/routers/hearing_summaries_test.py
+++ b/test/routers/hearing_summaries_test.py
@@ -77,7 +77,7 @@ def test_hearing_summaries_returns_server_error(mock_settings, mock_cda_settings
 def test_hearing_summaries_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
                                         mock_cda_client):
     OauthClient().token = None
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     mock_settings.return_value = override_get_cda_settings
     response = client.get("/v2/hearingsummaries/exception")

--- a/test/routers/hearing_test.py
+++ b/test/routers/hearing_test.py
@@ -76,7 +76,7 @@ def test_hearing_returns_server_error(mock_settings, mock_cda_settings, override
 def test_hearing_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
                               mock_cda_client):
     OauthClient().token = None
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     mock_settings.return_value = override_get_cda_settings
     response = client.get("/v2/hearing/00d0000c-00ff-00ec-b000-0000ac000003?date=01-04-2021")

--- a/test/routers/laa_references/patch_test.py
+++ b/test/routers/laa_references/patch_test.py
@@ -117,7 +117,7 @@ def test_laa_references_patch_returns_server_error(mock_settings, mock_cda_setti
 def test_laa_references_patch_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
                                            mock_cda_client):
     OauthClient().token = None
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     mock_settings.return_value = override_get_cda_settings
 

--- a/test/routers/laa_references/post_test.py
+++ b/test/routers/laa_references/post_test.py
@@ -103,7 +103,7 @@ def test_laa_references_post_returns_server_error(mock_settings, mock_cda_settin
 def test_laa_references_post_returns_none(mock_settings, mock_cda_settings, override_get_cda_settings,
                                           mock_cda_client):
     OauthClient().token = None
-    mock_cda_settings.return_value = CdaSettings(cda_endpoint="http://failed-test-url/", cda_secret="12345",
+    mock_cda_settings.return_value = CdaSettings(cda_endpoint="https://failed-test-url/", cda_secret="12345",
                                                  cda_uid="12345")
     mock_settings.return_value = override_get_cda_settings
 


### PR DESCRIPTION
## Description of change

Change tests to use https instead of http. Even though these are tests we should be using best practice in these circumstances. 

## Link to Jira Ticket

- [AAC-638](https://dsdmoj.atlassian.net/browse/AAC-638)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->