### PR TITLE
AAC-805 - Update ingress values to utilise new controller

### DIFF
--- a/helm_deploy/laa-court-data-api/values-dev.yaml
+++ b/helm_deploy/laa-court-data-api/values-dev.yaml
@@ -38,8 +38,8 @@ service:
 ingress:
   enabled: true
   namespace: laa-court-data-api-dev
+  className: modsec
   annotations:
-    kubernetes.io/ingress.class: modsec01
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On

--- a/helm_deploy/laa-court-data-api/values-production.yaml
+++ b/helm_deploy/laa-court-data-api/values-production.yaml
@@ -38,8 +38,8 @@ service:
 ingress:
   enabled: true
   namespace: laa-court-data-api-production
+  className: modsec
   annotations:
-    kubernetes.io/ingress.class: modsec01
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On

--- a/helm_deploy/laa-court-data-api/values-staging.yaml
+++ b/helm_deploy/laa-court-data-api/values-staging.yaml
@@ -38,8 +38,8 @@ service:
 ingress:
   enabled: true
   namespace: laa-court-data-api-staging
+  className: modsec
   annotations:
-    kubernetes.io/ingress.class: modsec01
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On

--- a/helm_deploy/laa-court-data-api/values-uat.yaml
+++ b/helm_deploy/laa-court-data-api/values-uat.yaml
@@ -38,8 +38,8 @@ service:
 ingress:
   enabled: true
   namespace: laa-court-data-api-uat
+  className: modsec
   annotations:
-    kubernetes.io/ingress.class: modsec01
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On

--- a/helm_deploy/laa-court-data-api/values.yaml
+++ b/helm_deploy/laa-court-data-api/values.yaml
@@ -38,8 +38,8 @@ service:
 ingress:
   enabled: true
   namespace: laa-court-data-api-dev
+  className: modsec
   annotations:
-    kubernetes.io/ingress.class: modsec01
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On


### PR DESCRIPTION
## Description of change

- Update ingress to use classname rather than annotation

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#step-2-create-a-new-ingress-resource

## Link to Jira Ticket

- [AAC-805](https://dsdmoj.atlassian.net/browse/AAC-805)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->