### PR TITLE
AAC-909 - Update CIrcleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.11
           docker_layer_caching: true
       - *login-ecr
       - build-docker-image
@@ -165,7 +164,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.11
           docker_layer_caching: true
       - build-docker-image
       - snyk/scan:


### PR DESCRIPTION
## Description of change

Remove the version lock on the Docker dependency in CircleCI so we can always get the latest for security and feature updates.

## Link to Jira Ticket

- [AAC-909](https://dsdmoj.atlassian.net/browse/AAC-909)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->