### PR TITLE
CTSKF-165 Update AWS deprecated login command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ references:
     run:
       name: ECR Login
       command: |
-          login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login --no-include-email)"
+          login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password --no-include-email)"
           ${login}
   _authenticate-kubectl: &authenticate-kubectl
     run:


### PR DESCRIPTION
## Description of change

AWS get-login command command is deprecated. Use `get-login-password` instead.

This fixes an issue during the deployment in CircleCI, which fails to login to ECR.

## Link to Jira Ticket

- [CTSKF-165](https://dsdmoj.atlassian.net/browse/CTSKF-165)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->