### PR TITLE
Increase the httpx timeout to 60s

### DIFF
--- a/laa_court_data_api_app/internal/court_data_adaptor_client.py
+++ b/laa_court_data_api_app/internal/court_data_adaptor_client.py
@@ -9,7 +9,7 @@ from ..internal.oauth_client import OauthClient
 from circuitbreaker import circuit
 
 logger = structlog.get_logger(__name__)
-http_client = httpx.AsyncClient(timeout=15.0)
+http_client = httpx.AsyncClient(timeout=60.0)
 
 
 class CourtDataAdaptorClient:


### PR DESCRIPTION
## Description of change

Increase the httpx timeout to 60s

This is because data fetching from CDA can be slow. We get ReadTimeouts after 15seconds. I believe some of the 424 failed dependencies returned to CDUI is because of the read timeout maxing at 15seconds.

Increasing this to 60s should give us more time to wait for a response from laa-court-data-adaptor.


## Link to Jira Ticket

- [CTSKF-](link to jira ticket)

## Additional information

After debugging a 424 response in CDUI, I noticed it correlated with a ReadTimeout from CDAPI. 

[Logs found here](https://docs.google.com/spreadsheets/d/1ZmSYa6Y9qnGogdLqi8XvW12riCyVxUqMrbnl5I-Y4wc/edit#gid=0)


![424 after 15seconds](https://user-images.githubusercontent.com/25043924/235975030-cfde223f-ff8d-4528-9bc7-80b8218b42f4.png)
