### PR TITLE
Handle a new error format for maat unlinking

### DIFF
--- a/laa_court_data_api_app/routers/laa_references.py
+++ b/laa_court_data_api_app/routers/laa_references.py
@@ -87,6 +87,9 @@ def formulated_response(cda_response, defendant_id, request_type):
 
 
 def parse_error_response(response):
-    error_string = re.findall(r"{[^}]*", response)
-    error_dict = re.findall(r":(.*?)=>\[\"(.*?)\"\]", error_string[0])
-    return dict((x, [y]) for x, y in error_dict)
+    if isinstance(response, str):
+        return {"error": [response]}
+    else:
+        error_string = re.findall(r"{[^}]*", response)
+        error_dict = re.findall(r":(.*?)=>\[\"(.*?)\"\]", error_string[0])
+        return dict((x, [y]) for x, y in error_dict)


### PR DESCRIPTION

## Description of change

When we send for a maat unlink to CDA, they may return a new error message of "Defendant not found" which describes that CDA does not have a local record of the defendant to MAAT linkage. It's a syncing issue between CDA and HMCTS that they will be looking to troubleshoot.

instead of the usual `{"errors": {"maat_reference": ["3141592 has no common platform data created against Maat application."]}} `
the new error message has a different format:
`{"error": "Defendant not found"}` 


## Link to Jira Ticket



## Screenshots or test evidence if applicable
