### PR TITLE
CTSKF-435 Use short-lived ECR credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.6.1
-  snyk: snyk/snyk@1.1.2
+  aws-cli: circleci/aws-cli@4.0.0
   helm: circleci/helm@1.2.0
   newman: postman/newman@0.0.2
+  slack: circleci/slack@4.6.1
+  snyk: snyk/snyk@1.1.2
 
 references:
   _save-requirements: &save-requirements
@@ -28,7 +29,8 @@ references:
     run:
       name: ECR Login
       command: |
-          AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
+          AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
+
   _authenticate-kubectl: &authenticate-kubectl
     run:
       name: Authenticate K8s
@@ -39,6 +41,7 @@ references:
           kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
           kubectl config use-context ${K8S_CLUSTER_NAME}
           kubectl --namespace=${K8S_NAMESPACE} get pods
+
   _push-docker-image: &push-docker-image
     run:
       name: Tag and push images
@@ -50,6 +53,7 @@ references:
               docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
               docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
           esac
+
 executors:
   build-image-executor:
     resource_class: small
@@ -65,6 +69,12 @@ executors:
           REPO_NAME: laa-court-data-api
 
 commands:
+  aws-cli-setup:
+    steps:
+     - aws-cli/setup:
+        role_arn: $ECR_ROLE_TO_ASSUME
+        region: $ECR_REGION
+
   install-requirements:
     steps:
       - *restore-requirements
@@ -94,6 +104,7 @@ commands:
                 --pull \
                 --tag app \
                 --file Dockerfile .
+
   deploy_to_environment:
     description: >
       Deploy image to the specified environment
@@ -103,6 +114,7 @@ commands:
         type: string
     steps:
       - checkout
+      - aws-cli-setup
       - *login-ecr
       - *authenticate-kubectl
       - run:
@@ -153,6 +165,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+      - aws-cli-setup
       - *login-ecr
       - build-docker-image
       - *push-docker-image
@@ -197,6 +210,7 @@ jobs:
     steps:
       - deploy_to_environment:
           environment: production
+
   postman-test:
     executor: newman/postman-newman-docker
     steps:


### PR DESCRIPTION
#### What
Implements changes mandated by Cloud Platform to deprecate the use of long-lived ECR credentials:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-circleci

#### Ticket
[CTSKF-435](https://dsdmoj.atlassian.net/browse/CTSKF-435)

#### Why
To allow the service to continue to be built and deployed to the MOJ Cloud Platform, while increasing the security of the process

#### How
* Adds the aw-cli orb to `.circleci/config.yml`
* Configures that orb to use the new `ECR_REGION` and `ECR_ROLE_TO_ASSUME` environment variables before logging in to ECR.
* Removes unnecessary references to the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables from the ECR log in step.

Steps outside of this PR:

* Merged PR in the Cloud Platform Environment repo to enable short-lived creds
* Added the four new environment variables to the `laa-court-data-api` project in CircleCI.
* Deleted the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables from the `laa-court-data-api` project in CircleCI.

[CTSKF-435]: https://dsdmoj.atlassian.net/browse/CTSKF-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ